### PR TITLE
feat: include full text for RSS feed

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -68,6 +68,7 @@ params:
   # list page only
   hide_summary: false
   show_rss_button_in_section_term_list: false
+  ShowFullTextinRSS: true
 
   assets:
     disable_hljs: true # to disable highlight.js


### PR DESCRIPTION
Full text in an RSS feed is more convenient for users, see [1] for more information.

Summary of the motivation:
- Easier for users because they don't have to visit the blog
- Text within the article can be searched with the reader
- Offline reading will be possible

[1]: https://openrss.org/blog/full-text-in-rss-please